### PR TITLE
F! Bare Sock Client non alloc for EndPoint when receive data

### DIFF
--- a/Pixockets/BareSock.cs
+++ b/Pixockets/BareSock.cs
@@ -15,13 +15,13 @@ namespace Pixockets
         private IPEndPoint _remoteEndPoint;
         private IPEndPoint _receiveEndPoint;
 
-        private readonly BufferPoolBase _buffersPool;
+        protected readonly BufferPoolBase BuffersPool;
 
         public BareSock(BufferPoolBase buffersPool, AddressFamily addressFamily)
         {
             SysSock = new Socket(addressFamily, SocketType.Dgram, ProtocolType.Udp);
             SysSock.Blocking = false;
-            _buffersPool = buffersPool;
+            BuffersPool = buffersPool;
         }
 
         public override void Connect(IPAddress address, int port)
@@ -60,7 +60,7 @@ namespace Pixockets
             finally
             {
                 if (putBufferToPool)
-                    _buffersPool.Put(buffer);
+                    BuffersPool.Put(buffer);
             }
         }
 
@@ -78,7 +78,7 @@ namespace Pixockets
             finally
             {
                 if (putBufferToPool)
-                    _buffersPool.Put(buffer);
+                    BuffersPool.Put(buffer);
             }
         }
 
@@ -96,7 +96,7 @@ namespace Pixockets
                 return false;
             }
 
-            var buffer = _buffersPool.Get(MTU);
+            var buffer = BuffersPool.Get(MTU);
             EndPoint remoteEP = _receiveEndPoint;
             try
             {
@@ -116,7 +116,7 @@ namespace Pixockets
                 // TODO: do something
             }
 
-            _buffersPool.Put(buffer);
+            BuffersPool.Put(buffer);
             return false;
         }
 

--- a/Pixockets/BareSockClient.cs
+++ b/Pixockets/BareSockClient.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net.Sockets;
+
+namespace Pixockets
+{
+    public class BareSockClient : BareSock
+    {
+        public BareSockClient(BufferPoolBase buffersPool, AddressFamily addressFamily) : base(buffersPool, addressFamily)
+        {
+        }
+        
+        public override bool Receive(ref ReceivedPacket packet)
+        {
+            try
+            {
+                if (SysSock.Available == 0)
+                {
+                    return false;
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            var buffer = BuffersPool.Get(MTU);
+            try
+            {
+                var bytesReceived = SysSock.Receive(buffer, MTU, SocketFlags.None);
+                if (bytesReceived > 0)
+                {
+                    packet.Buffer = buffer;
+                    packet.Offset = 0;
+                    packet.Length = bytesReceived;
+                    packet.EndPoint = RemoteEndPoint;
+
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+                // TODO: do something
+            }
+
+            BuffersPool.Put(buffer);
+            return false;
+        }
+    }
+}

--- a/Pixockets/Pixockets.csproj
+++ b/Pixockets/Pixockets.csproj
@@ -37,6 +37,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BareSockClient.cs" />
     <Compile Include="FragmentBuffer.cs" />
     <Compile Include="FragmentedPacket.cs" />
     <Compile Include="NotAckedPacket.cs" />


### PR DESCRIPTION
BareSock.cs uses SysSock.ReceiveFrom method. This is produces allocation of RemoteEndPoint.
I'm suggesting to use SysSock.Receive which not produces any allocations. It is useful for client because, it receive data only from one endpoint. This code was tested in aftermath project, release 0.8.